### PR TITLE
🛠️ Replace xpd `broker.name` with `tiledInserter` to handle auth

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -50,7 +50,7 @@ db = Broker(c)
 
 nslsii.configure_base(
     get_ipython().user_ns,
-    "xpd",
+    TiledInserter,
     pbar=True,
     bec=True,
     magics=True,


### PR DESCRIPTION
Yesterday in some of the haste to commit this change was omitted, today it has been corrected.